### PR TITLE
Fixed error on/admin/structure/types/manage/page (temporary solution, se...

### DIFF
--- a/flag.module
+++ b/flag.module
@@ -374,9 +374,11 @@ function flag_entity_extra_field_info() {
  */
 function flag_form_node_type_form_alter(&$form, &$form_state, $form_id) {
   global $user;
-  $flags = \Drupal::service('flag')->getFlags('node', $form['#node_type']->type, $user);
+  $node_type = $form_state['controller']->getEntity();
+  $flags = \Drupal::service('flag')->getFlags('node', $node_type->id(), $user);
   foreach ($flags as $flag) {
-    if ($flag->show_on_form) {
+    // @todo: Revisit when form functionality is implemented.
+    if (!empty($flag->show_on_form)) {
       // To be able to process node tokens in flag labels, we create a fake
       // node and store it in the flag's cache for replace_tokens() to find,
       // with a fake ID.

--- a/src/FlagService.php
+++ b/src/FlagService.php
@@ -86,7 +86,7 @@ class FlagService {
 
     $filtered_flags = array();
     foreach ($flags as $flag) {
-      if ($flag->canFlag($account) || $flag->canUnflag($account)) {
+      if ($flag->hasActionAccess('flag ' . $flag->id(), $account) || $flag->hasActionAccess('unflag ' . $flag->id(), $account)) {
         $filtered_flags[] = $flag;
       }
     }


### PR DESCRIPTION
This patch contains a fix for the error messages on "/admin/structure/types/manage/page":
- Replaced functions canFlag() and canUnflag() with the recently added function hasActionAccess().
- See todo comment: "Revisit when form functionality is implemented.".
