### PR TITLE
Fixed hook requirements to enable successful installation.

### DIFF
--- a/flag.install
+++ b/flag.install
@@ -76,9 +76,9 @@ function flag_uninstall() {
  * Implements hook_requirements().
  */
 function flag_requirements($phase) {
-  /*
-  $requirements = array();
 
+  $requirements = array();
+  /*
   if ($phase == 'runtime') {
     if (module_exists('translation') && !module_exists('translation_helpers')) {
       $requirements['flag_translation'] = array(
@@ -107,6 +107,6 @@ function flag_requirements($phase) {
       }
     }
   }
-  return $requirements;
   */
+  return $requirements;
 }


### PR DESCRIPTION
This threw an error because nothing was returned. Now fixed for installation purposes.
