### PR TITLE
Fix test group

### DIFF
--- a/src/Tests/FlagSimpleTest.php
+++ b/src/Tests/FlagSimpleTest.php
@@ -14,7 +14,7 @@ use Drupal\user\Entity\Role;
 /**
  * Tests the Flag form actions (add/edit/delete).
  *
- * @group Flag
+ * @group flag
  */
 class FlagSimpleTest extends WebTestBase {
 


### PR DESCRIPTION
The test group doesn't match the one in .travis, this starts running the tests. The module_exists() fails are fixed in #38.
