### PR TITLE
applied coding standard changes ONLY to comments in ActionLink

### DIFF
--- a/src/Plugin/ActionLink/AJAXactionLink.php
+++ b/src/Plugin/ActionLink/AJAXactionLink.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @file
+ * Contains \Drupal\flag\Plugin\ActionLink\AJAXactionLink.
+ */
 
 namespace Drupal\flag\Plugin\ActionLink;
 
@@ -17,6 +21,9 @@ use Drupal\flag\FlagInterface;
  */
 class AJAXactionLink extends ActionLinkTypeBase{
 
+  /**
+   * {@inheritdoc}
+   */
   public function routeName($action = NULL) {
     if ($action === 'unflag') {
       return 'flag.link_unflag.json';
@@ -25,6 +32,9 @@ class AJAXactionLink extends ActionLinkTypeBase{
     return 'flag.link_flag.json';
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function renderLink($action, FlagInterface $flag, EntityInterface $entity) {
     $render = parent::renderLink($action, $flag, $entity);
     $render['#attached']['library'][] = 'core/drupal.ajax';

--- a/src/Plugin/ActionLink/ConfirmForm.php
+++ b/src/Plugin/ActionLink/ConfirmForm.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: tess
- * Date: 3/4/14
- * Time: 9:51 PM
+ * @file
+ * Contains \Drupal\flag\Plugin\ActionLink\ConfirmForm.
  */
 
 namespace Drupal\flag\Plugin\ActionLink;
@@ -22,6 +20,9 @@ use Drupal\flag\ActionLinkTypeBase;
  */
 class ConfirmForm extends ActionLinkTypeBase {
 
+  /**
+   * {@inheritdoc}
+   */
   public function routeName($action = NULL) {
     if ($action == 'unflag') {
       return 'flag.confirm_unflag';
@@ -30,6 +31,9 @@ class ConfirmForm extends ActionLinkTypeBase {
     return 'flag.confirm_flag';
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function defaultConfiguration() {
     $options = parent::defaultConfiguration();
 
@@ -39,6 +43,9 @@ class ConfirmForm extends ActionLinkTypeBase {
     return $options;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function buildConfigurationForm(array $form, array &$form_state) {
     $form = parent::buildConfigurationForm($form, $form_state);
 
@@ -73,6 +80,9 @@ class ConfirmForm extends ActionLinkTypeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function submitConfigurationForm(array &$form, array &$form_state) {
     parent::submitConfigurationForm($form, $form_state);
     $this->configuration['flag_confirmation'] = $form_state['values']['flag_confirmation'];

--- a/src/Plugin/ActionLink/Reload.php
+++ b/src/Plugin/ActionLink/Reload.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: tess
- * Date: 11/14/13
- * Time: 8:21 PM
+ * @file
+ * Contains Drupal\flag\Plugin\ActionLink\Reload.
  */
 
 namespace Drupal\flag\Plugin\ActionLink;
@@ -22,7 +20,7 @@ use Drupal\flag\ActionLinkTypeBase;
 class Reload extends ActionLinkTypeBase {
 
   /**
-   * @return string
+   * {@inheritdoc}
    */
   public function routeName($action = NULL) {
     if ($action === 'unflag') {


### PR DESCRIPTION
Hi,

For the src/Plugin/ActionLink directory ONLY

I have brought the comment upto what I think is the drupal core coding standard.

I hope this helps
