### PR TITLE
Remove unecessary $form_state['controller'] hack

### DIFF
--- a/flag.module
+++ b/flag.module
@@ -326,7 +326,7 @@ function flag_entity_extra_field_info() {
  */
 function flag_form_node_type_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   global $user;
-  $node_type = $form_state['controller']->getEntity();
+  $node_type = $form_state->getFormObject()->getEntity();
   $flags = \Drupal::service('flag')->getFlags('node', $node_type->id(), $user);
   foreach ($flags as $flag) {
     // @todo: Revisit when form functionality is implemented.

--- a/src/Form/FlagFormBase.php
+++ b/src/Form/FlagFormBase.php
@@ -191,7 +191,7 @@ abstract class FlagFormBase extends EntityForm {
         'class' => ['flag-link-options'],
       ],
       '#limit_validation_errors' => [['link_type']],
-      '#submit' => [[$this, 'submitSelectPlugin']],
+      '#submit' => ['::submitSelectPlugin'],
       '#required' => TRUE,
       '#executes_submit_callback' => TRUE,
       '#ajax' => [
@@ -204,7 +204,7 @@ abstract class FlagFormBase extends EntityForm {
     $form['display']['link_type_submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Update'),
-      '#submit' => [[$this, 'submitSelectPlugin']],
+      '#submit' => ['::submitSelectPlugin'],
       '#weight' => 20,
       '#attributes' => ['class' => ['js-hide']],
     ];
@@ -237,10 +237,7 @@ abstract class FlagFormBase extends EntityForm {
   public function submitSelectPlugin(array $form, FormStateInterface $form_state) {
     $this->entity = $this->buildEntity($form, $form_state);
 
-    $form_state['rebuild'] = TRUE;
-    // This is necessary because there are two different instances of the form
-    // object. Core should handle this.
-    $form_state['build_info']['callback_object'] = $form_state['controller'];
+    $form_state->setRebuild(TRUE);
   }
 
   /**


### PR DESCRIPTION
$form_state['controller'] has been removed as it is now the normal form object. The submit improvements allow to remove the hack there. Did not test manually.
