### PR TITLE
Fixed invalid url in watchdog messages and converted deprecated watchdog...

### DIFF
--- a/src/Form/FlagFormBase.php
+++ b/src/Form/FlagFormBase.php
@@ -271,11 +271,11 @@ abstract class FlagFormBase extends EntityForm {
     $url = $flag->url();
     if ($status == SAVED_UPDATED) {
       drupal_set_message(t('Flag %label has been updated.', ['%label' => $flag->label()]));
-      watchdog('flag', 'Flag %label has been updated.', ['%label' => $flag->label()], WATCHDOG_NOTICE, l(t('Edit'), $url . '/edit'));
+      $this->logger('flag')->notice('Flag %label has been updated.', ['%label' => $flag->label(), 'link' => l(t('Edit'), $url)]);
     }
     else {
       drupal_set_message(t('Flag %label has been added.', ['%label' => $flag->label()]));
-      watchdog('flag', 'Flag %label has been added.', ['%label' => $flag->label()], WATCHDOG_NOTICE, l(t('Edit'), $url . '/edit'));
+      $this->logger('flag')->notice('Flag %label has been added.', ['%label' => $flag->label(), 'link' => l(t('Edit'), $url)]);
     }
 
     // We clear caches more vigorously if the flag was new.


### PR DESCRIPTION
Love the module... I want to see it succeed....

After creating a new flag I went to 

/admin/reports/dblog

to look at the associated message, with its  handy 'Edit' link.
the  link is unfortunately invalid :(

"If" you created a flag called "test" the the link url would be 

/admin/structure/flags/manage/test/edit 

in the current way of doing things the problem is the appended '/edit' in mucks the link up.

I have test it and shown the 

/admin/structure/flags/manage/test/ works just fine.

Also watchdog is deprecated, but $this->logger comes for 'free' from FormBase.
